### PR TITLE
Step 2:  Add writeCommand() method to simplify PROGMEM usage

### DIFF
--- a/ESP8266wifi.cpp
+++ b/ESP8266wifi.cpp
@@ -450,8 +450,8 @@ WifiMessage ESP8266wifi::listenForIncomingMessage(int timeout){
 // NOTE: strings are stored in PROGMEM (auto-copied by this method)
 byte ESP8266wifi::readCommand(int timeout, const char* text1, const char* text2) {
     // setup buffers on stack & copy data from PROGMEM pointers
-    char buf1[16] = {0};
-    char buf2[16] = {0};
+    char buf1[16] = {'\0'};
+    char buf2[16] = {'\0'};
     if (text1 != NULL)
         strcpy_P(buf1, (char *) text1);
     if (text2 != NULL)

--- a/ESP8266wifi.h
+++ b/ESP8266wifi.h
@@ -138,7 +138,6 @@ private:
     char msgIn[26]; //buffer for listen method = limit of incoming message..
     
     char buf[26];
-    char buf2[16];
     
     byte readCommand(int timeout, const char* text1 = NULL, const char* text2 = NULL);
 

--- a/ESP8266wifi.h
+++ b/ESP8266wifi.h
@@ -140,8 +140,8 @@ private:
     char buf[26];
     char buf2[16];
     
-    byte findString(int timeout,  const char* what);
-    byte findString(int timeout,  const char* what,  const char* what2);
+    byte readCommand(int timeout, const char* text1 = NULL, const char* text2 = NULL);
+
     void loadString(const char* str, char* out);
     
     Stream* _dbgSerial;

--- a/ESP8266wifi.h
+++ b/ESP8266wifi.h
@@ -136,13 +136,10 @@ private:
     
     char msgOut[26];//buffer for send method
     char msgIn[26]; //buffer for listen method = limit of incoming message..
-    
-    char buf[26];
-    
+
+    void writeCommand(const char* text1, const char* text2 = NULL);
     byte readCommand(int timeout, const char* text1 = NULL, const char* text2 = NULL);
 
-    void loadString(const char* str, char* out);
-    
     Stream* _dbgSerial;
 };
 


### PR DESCRIPTION
Includes ekstrand/ESP8266wifi#1 (i.e. should be applied **after**)
- Adds writeCommand() method for serial out of PROGMEM strings
- Removes the loadString() method, no longer used
- Removes instance buf variable, using stack-based buffer instead
