### PR TITLE
Refactored send() and added String support to API

### DIFF
--- a/ESP8266wifi.cpp
+++ b/ESP8266wifi.cpp
@@ -314,13 +314,12 @@ void ESP8266wifi::watchdog(){
 }
 
 /*
- * Will always send with a linefeed at the end..
+ * Send string (if channel is connected of course)
  */
 bool ESP8266wifi::send(char channel, const char * message, bool sendNow){
     watchdog();
-    byte totalChars = strlen(message) +  strlen(msgOut) + 1; // add one to account for null char...
-    strcat(msgOut, message);
-    msgOut[strlen(msgOut)] = '\0';
+    byte avail = sizeof(msgOut) - strlen(msgOut) - 1;
+    strncat(msgOut, message, avail);
     if (!sendNow)
         return true;
     byte length = strlen(msgOut);
@@ -351,10 +350,6 @@ bool ESP8266wifi::send(char channel, const char * message, bool sendNow){
         flags.connectedToServer = false;
     msgOut[0] = '\0';
     return false;
-}
-
-bool ESP8266wifi::send(char channel, const char * message){
-    return send(channel,message,true);
 }
 
 WifiMessage ESP8266wifi::listenForIncomingMessage(int timeout){

--- a/ESP8266wifi.cpp
+++ b/ESP8266wifi.cpp
@@ -149,6 +149,7 @@ bool ESP8266wifi::begin() {
 bool ESP8266wifi::isStarted(){
     return flags.started;
 }
+
 void ESP8266wifi::restart(){
     begin();
     
@@ -160,6 +161,10 @@ void ESP8266wifi::restart(){
     
     if(flags.serverConfigured)
         connectToServer();
+}
+
+bool ESP8266wifi::connectToAP(String& ssid, String& password) {
+    return connectToAP(ssid.c_str(), password.c_str());
 }
 
 bool ESP8266wifi::connectToAP(const char* ssid, const char* password){//TODO make timeout config or parameter??
@@ -193,6 +198,10 @@ void ESP8266wifi::setTransportToUDP(){
 
 void ESP8266wifi::setTransportToTCP(){
     flags.connectToServerUsingTCP = true;
+}
+
+bool ESP8266wifi::connectToServer(String& ip, String& port) {
+    return connectToServer(ip.c_str(), port.c_str());
 }
 
 bool ESP8266wifi::connectToServer(const char* ip, const char* port){//TODO make timeout config or parameter??
@@ -316,6 +325,10 @@ void ESP8266wifi::watchdog(){
 /*
  * Send string (if channel is connected of course)
  */
+bool ESP8266wifi::send(char channel, String& message, bool sendNow) {
+    return send(channel, message.c_str(), sendNow);
+}
+
 bool ESP8266wifi::send(char channel, const char * message, bool sendNow){
     watchdog();
     byte avail = sizeof(msgOut) - strlen(msgOut) - 1;

--- a/ESP8266wifi.h
+++ b/ESP8266wifi.h
@@ -89,15 +89,9 @@ public:
     
     
     /*
-     * Adding message to be sent later
+     * Send string (if channel is connected of course)
      */
-    
-    bool send(char channel, const char * message);
-    
-    /*
-     * Sending string (if channel is connected of course)
-     */
-    bool send(char channel, const char * message, bool sendNow);
+    bool send(char channel, const char * message, bool sendNow = true);
     
     /*
      * Default is true.

--- a/ESP8266wifi.h
+++ b/ESP8266wifi.h
@@ -64,6 +64,7 @@ public:
      * Connect to AP using wpa encryption
      * (reconnect logic is applied, if conn lost or not established, or esp8266 restarted)
      */
+    bool connectToAP(String& ssid, String& password);
     bool connectToAP(const char* ssid, const char* password);
     bool isConnectedToAP();
     
@@ -75,6 +76,7 @@ public:
     void setTransportToUDP();
     //Default..
     void setTransportToTCP();
+    bool connectToServer(String& ip, String& port);
     bool connectToServer(const char* ip, const char* port);
     void disconnectFromServer();
     bool isConnectedToServer();
@@ -91,6 +93,7 @@ public:
     /*
      * Send string (if channel is connected of course)
      */
+    bool send(char channel, String& message, bool sendNow = true);
     bool send(char channel, const char * message, bool sendNow = true);
     
     /*


### PR DESCRIPTION
- Default value for last argument to send()
- Safer handling of maximum message buffer length
- Support for `String` use in API
