### PR TITLE
Update ESP8266wifi.cpp

### DIFF
--- a/ESP8266wifi.cpp
+++ b/ESP8266wifi.cpp
@@ -24,7 +24,7 @@ const char LINK_IS_NOT[] PROGMEM = "link is not";
 const char PROMPT[] PROGMEM = ">";
 const char BUSY[] PROGMEM =  "busy";
 const char LINKED[] PROGMEM = "Linked";
-const char ALREADY[] PROGMEM = "ALREAY";//yes typo in firmware..
+const char ALREADY[] PROGMEM = "ALREADY";//yes typo in firmware..
 const char READY[] PROGMEM = "ready";
 const char NO_IP[] PROGMEM = "0.0.0.0";
 


### PR DESCRIPTION
Typo.

I found out that posting to thingspeak doesnt work probably because you force CIPSTART to id 4.

SERVER value and cipstart and cipmux are hardcoded and not dynamic. Is there a way to set it to single mode to see if it works against thingspeak?

const char CIPSTART[] PROGMEM = "AT+CIPSTART=4,\"";"
to
const char CIPSTART[] PROGMEM = "AT+CIPSTART=\"";

and
const char CIPMUX_1[] PROGMEM = "AT+CIPMUX=1";
to
const char CIPMUX_1[] PROGMEM = "AT+CIPMUX=0";

and defining SERVER to 'nothing' to CIPSEND doesnt get forced to send a defined id.
Seems like thingspeak doesnt allow multiple connections or there is something else wrong.

[System Ready, Vendor:www.ai-thinker.com]
AT+CIPSTART="TCP","184.106.153.149",80

OK
Linked
AT+CIPSEND=4,13     

type error
Ping ping..

Error
