### PR TITLE
Add methods for AP scanning (CWLAP)

### DIFF
--- a/ESP8266wifi.cpp
+++ b/ESP8266wifi.cpp
@@ -669,7 +669,6 @@ uint8_t ESP8266wifi::listAps(struct listApDataItem* data, uint8_t len, char* spe
     byte entryOrOk = 0;
     byte code = 0;
     char* token;
-    uint8_t curEntry = 0;
     uint8_t entries = 0;
     memset(msgIn, '\0', sizeof(msgIn));
     memset(data, 0, sizeof(listApDataItem) * len);
@@ -710,9 +709,8 @@ uint8_t ESP8266wifi::listAps(struct listApDataItem* data, uint8_t len, char* spe
                 //get data
                 readBuffer(msgIn, sizeof(msgIn) - 1, '\n', 500);
 
-                entries++;                
-                if(curEntry >= len) {
-                    continue; //only get remaining number of aps, do not store information.
+                if(entries >= len) {
+                    continue; //given buffer is full: only count remaining number of aps
                 }
                 
                 //tokenize buffer
@@ -730,25 +728,25 @@ uint8_t ESP8266wifi::listAps(struct listApDataItem* data, uint8_t len, char* spe
                 
                 token = strtok(NULL, "(,\")");
                 if(token) { //ssid
-                    strncpy(data[curEntry].ssid, token, sizeof(data[curEntry].ssid));
+                    strncpy(data[entries].ssid, token, sizeof(data[entries].ssid));
                 } else goto error;
                 
                 token = strtok(NULL, "(,\")");
                 if(token) { //rssi
-                    data[curEntry].rssi = atoi(token);
+                    data[entries].rssi = atoi(token);
                 } else goto error;
 
                 token = strtok(NULL, ",\"");
                 if(token) { //mac
-                    strncpy(data[curEntry].mac, token, sizeof(data[curEntry].mac));
+                    strncpy(data[entries].mac, token, sizeof(data[entries].mac));
                 } else goto error;
                 
                 token = strtok(NULL, "(,\")");
                 if(token) { //channel
-                    data[curEntry].channel = atoi(token);
+                    data[entries].channel = atoi(token);
                 } else goto error;
                 
-                curEntry++;
+                entries++;
             } else goto error;
         } while(true);
     }

--- a/ESP8266wifi.cpp
+++ b/ESP8266wifi.cpp
@@ -595,7 +595,7 @@ WifiMessage ESP8266wifi::getIncomingMessage(void) {
 }
 
 // Writes commands (from PROGMEM) to serial output
-void ESP8266wifi::writeCommand(const char* text1 = NULL, const char* text2) {
+void ESP8266wifi::writeCommand(const char* text1, const char* text2) {
     char buf[16] = {'\0'};
     strcpy_P(buf, (char *) text1);
     _serialOut->print(buf);

--- a/ESP8266wifi.cpp
+++ b/ESP8266wifi.cpp
@@ -709,11 +709,10 @@ char ESP8266wifi::readChar() {
 uint8_t ESP8266wifi::listAps(struct listApDataItem* data, uint8_t len, char* specificSSID) {
 	byte entryOrOk = 0;
 	byte code = 0;
-	char mybuf[128];
 	char* token;
 	uint8_t curEntry = 0;
 	uint8_t entries = 0;
-	memset(mybuf, '\0', sizeof(mybuf));
+	memset(msgIn, '\0', sizeof(msgIn));
 	memset(data, 0, sizeof(listApDataItem) * len);
 
 	if(specificSSID != NULL) {
@@ -746,7 +745,7 @@ uint8_t ESP8266wifi::listAps(struct listApDataItem* data, uint8_t len, char* spe
 				}
 				
 				//tokenize buffer
-				token = strtok(mybuf, ":(,\")");
+				token = strtok(msgIn, ":(,\")");
 				if(token) { //ap type
 					switch(*token) {
 						case '0': data[curEntry].type = WIFI_OPEN; break;

--- a/ESP8266wifi.cpp
+++ b/ESP8266wifi.cpp
@@ -738,7 +738,7 @@ uint8_t ESP8266wifi::listAps(struct listApDataItem* data, uint8_t len, char* spe
 				return entries; //OK, exit loop.
 			} else if(entryOrOk == 1) {
 				//get data
-				readBuffer2(mybuf, sizeof(mybuf) - 1, '\n');
+				readBuffer(msgIn, sizeof(msgIn) - 1, '\n', 500);
 
 				entries++;				
 				if(curEntry >= len) {
@@ -748,18 +748,13 @@ uint8_t ESP8266wifi::listAps(struct listApDataItem* data, uint8_t len, char* spe
 				//tokenize buffer
 				token = strtok(mybuf, ":(,\")");
 				if(token) { //ap type
-					if(*token == '0') {
-						data[curEntry].type = WIFI_OPEN;
-					} else if(*token == '1') {
-						data[curEntry].type = WIFI_WEP;
-					} else if(*token == '2') {
-						data[curEntry].type = WIFI_WPA_PSK;
-					} else if(*token == '3') {
-						data[curEntry].type = WIFI_WPA2_PSK;
-					} else if(*token == '4') {
-						data[curEntry].type = WIFI_WPA_WPA2_PSK;
-					} else {
-						goto error;
+					switch(*token) {
+						case '0': data[curEntry].type = WIFI_OPEN; break;
+						case '1': data[curEntry].type = WIFI_WEP; break;
+						case '2': data[curEntry].type = WIFI_WPA_PSK; break;
+						case '3': data[curEntry].type = WIFI_WPA2_PSK; break;
+						case '4': data[curEntry].type = WIFI_WPA_WPA2_PSK; break;
+						default: goto error;
 					}
 				} else goto error;
 				

--- a/ESP8266wifi.cpp
+++ b/ESP8266wifi.cpp
@@ -645,7 +645,7 @@ byte ESP8266wifi::readBuffer(char* buf, byte count, char delim, int timeout) {
     unsigned long stop = millis() + timeout;
 
     while (pos < count) {
-        if(_serialIn->available()) {
+        while(_serialIn->available()) {
             if (_serialIn->peek() == delim)
                 break;
             buf[pos++] = readChar();

--- a/ESP8266wifi.cpp
+++ b/ESP8266wifi.cpp
@@ -689,7 +689,7 @@ uint8_t ESP8266wifi::listAps(struct listApDataItem* data, uint8_t len, char* spe
                 _serialOut->print(specificChannel);
             }
         }
-		writeCommand(EOL);
+		_serialOut->println();
     } else {
 		//request all aps in range
         writeCommand(CWLAP1, EOL);

--- a/ESP8266wifi.cpp
+++ b/ESP8266wifi.cpp
@@ -701,8 +701,8 @@ char ESP8266wifi::readChar() {
     char c = _serialIn->read();
     if (flags.debug)
         _dbgSerial->print(c);
-    else
-        delayMicroseconds(50); // don't know why
+    //else
+        //delayMicroseconds(50); // don't know why
     return c;
 }
 

--- a/ESP8266wifi.cpp
+++ b/ESP8266wifi.cpp
@@ -641,20 +641,20 @@ byte ESP8266wifi::readCommand(int timeout, const char* text1, const char* text2)
 
 // Read count chars to a buffer, or until delim char is found, or the request timed out.
 byte ESP8266wifi::readBuffer(char* buf, byte count, char delim, int timeout) {
-	byte pos = 0;
+    byte pos = 0;
     unsigned long stop = millis() + timeout;
 
-	while (pos < count) {
-		if(_serialIn->available()) {
-			if (_serialIn->peek() == delim)
-				break;
-			buf[pos++] = readChar();
-		}
-		if(timeout > 0 && millis() > stop)
-			break; //timed out.
-	}
-	buf[pos] = '\0';
-	return pos;
+    while (pos < count) {
+        if(_serialIn->available()) {
+            if (_serialIn->peek() == delim)
+                break;
+            buf[pos++] = readChar();
+        }
+        if(timeout > 0 && millis() > stop)
+            break; //timed out.
+    }
+    buf[pos] = '\0';
+    return pos;
 }
 
 // Reads a single char from serial input (with debug printout if configured)
@@ -666,96 +666,96 @@ char ESP8266wifi::readChar() {
 }
 
 uint8_t ESP8266wifi::listAps(struct listApDataItem* data, uint8_t len, char* specificSSID, char* specificMAC, int specificChannel) {
-	byte entryOrOk = 0;
-	byte code = 0;
-	char* token;
-	uint8_t curEntry = 0;
-	uint8_t entries = 0;
-	memset(msgIn, '\0', sizeof(msgIn));
-	memset(data, 0, sizeof(listApDataItem) * len);
+    byte entryOrOk = 0;
+    byte code = 0;
+    char* token;
+    uint8_t curEntry = 0;
+    uint8_t entries = 0;
+    memset(msgIn, '\0', sizeof(msgIn));
+    memset(data, 0, sizeof(listApDataItem) * len);
 
-	if(specificSSID != NULL) {
-		//issue request for specific ap; may not work on older firmware
-		writeCommand(CWLAP3);
-		_serialOut->print(specificSSID);
-		writeCommand(DOUBLE_QUOTE);
-		
-		if(specificMAC != NULL) {
-			writeCommand(COMMA, DOUBLE_QUOTE);
-			_serialOut->print(specificMAC);
-			writeCommand(DOUBLE_QUOTE);
+    if(specificSSID != NULL) {
+        //issue request for specific ap; may not work on older firmware
+        writeCommand(CWLAP3);
+        _serialOut->print(specificSSID);
+        writeCommand(DOUBLE_QUOTE);
+        
+        if(specificMAC != NULL) {
+            writeCommand(COMMA, DOUBLE_QUOTE);
+            _serialOut->print(specificMAC);
+            writeCommand(DOUBLE_QUOTE);
 
-			if(specificChannel > 0) {
-				writeCommand(COMMA);
-				_serialOut->print(specificChannel);
-			}
-		}
-		_serialOut->println();
-	} else {
-		writeCommand(CWLAP1, EOL);
-	}
+            if(specificChannel > 0) {
+                writeCommand(COMMA);
+                _serialOut->print(specificChannel);
+            }
+        }
+        _serialOut->println();
+    } else {
+        writeCommand(CWLAP1, EOL);
+    }
 
-	code = readCommand(4000, CWLAP1, ERROR);
-	if (code == 2){
-		restart();
-		goto error; //something went wrong.
+    code = readCommand(4000, CWLAP1, ERROR);
+    if (code == 2){
+        restart();
+        goto error; //something went wrong.
     } else if (code == 1) {
-		do {
-			entryOrOk = readCommand(4000, CWLAP2, OK);
+        do {
+            entryOrOk = readCommand(4000, CWLAP2, OK);
 
-			if(entryOrOk == 2) {
-				return entries; //OK, exit loop.
-			} else if(entryOrOk == 1) {
-				//get data
-				readBuffer(msgIn, sizeof(msgIn) - 1, '\n', 500);
+            if(entryOrOk == 2) {
+                return entries; //OK, exit loop.
+            } else if(entryOrOk == 1) {
+                //get data
+                readBuffer(msgIn, sizeof(msgIn) - 1, '\n', 500);
 
-				entries++;				
-				if(curEntry >= len) {
-					continue; //only get remaining number of aps, do not store information.
-				}
-				
-				//tokenize buffer
-				token = strtok(msgIn, ":(,\")");
-				if(token) { //ap type
-					switch(*token) {
-						case '0': data[curEntry].type = WIFI_OPEN; break;
-						case '1': data[curEntry].type = WIFI_WEP; break;
-						case '2': data[curEntry].type = WIFI_WPA_PSK; break;
-						case '3': data[curEntry].type = WIFI_WPA2_PSK; break;
-						case '4': data[curEntry].type = WIFI_WPA_WPA2_PSK; break;
-						default: goto error;
-					}
-				} else goto error;
-				
-				token = strtok(NULL, "(,\")");
-				if(token) { //ssid
-					strncpy(data[curEntry].ssid, token, sizeof(data[curEntry].ssid));
-				} else goto error;
-				
-				token = strtok(NULL, "(,\")");
-				if(token) { //rssi
-					data[curEntry].rssi = atoi(token);
-				} else goto error;
+                entries++;                
+                if(curEntry >= len) {
+                    continue; //only get remaining number of aps, do not store information.
+                }
+                
+                //tokenize buffer
+                token = strtok(msgIn, ":(,\")");
+                if(token) { //ap type
+                    switch(*token) {
+                        case '0': data[curEntry].type = WIFI_OPEN; break;
+                        case '1': data[curEntry].type = WIFI_WEP; break;
+                        case '2': data[curEntry].type = WIFI_WPA_PSK; break;
+                        case '3': data[curEntry].type = WIFI_WPA2_PSK; break;
+                        case '4': data[curEntry].type = WIFI_WPA_WPA2_PSK; break;
+                        default: goto error;
+                    }
+                } else goto error;
+                
+                token = strtok(NULL, "(,\")");
+                if(token) { //ssid
+                    strncpy(data[curEntry].ssid, token, sizeof(data[curEntry].ssid));
+                } else goto error;
+                
+                token = strtok(NULL, "(,\")");
+                if(token) { //rssi
+                    data[curEntry].rssi = atoi(token);
+                } else goto error;
 
-				token = strtok(NULL, ",\"");
-				if(token) { //mac
-					strncpy(data[curEntry].mac, token, sizeof(data[curEntry].mac));
-				} else goto error;
-				
-				token = strtok(NULL, "(,\")");
-				if(token) { //channel
-					data[curEntry].channel = atoi(token);
-				} else goto error;
-				
-				curEntry++;
-			} else goto error;
-		} while(true);
-	}
-	
+                token = strtok(NULL, ",\"");
+                if(token) { //mac
+                    strncpy(data[curEntry].mac, token, sizeof(data[curEntry].mac));
+                } else goto error;
+                
+                token = strtok(NULL, "(,\")");
+                if(token) { //channel
+                    data[curEntry].channel = atoi(token);
+                } else goto error;
+                
+                curEntry++;
+            } else goto error;
+        } while(true);
+    }
+    
 error:
-	return 0;
+    return 0;
 }
 
 uint8_t ESP8266wifi::listAp(struct listApDataItem* data, char* ssid, char* mac, int channel) {
-	return listAps(data, 1, ssid, mac, channel);
+    return listAps(data, 1, ssid, mac, channel);
 }

--- a/ESP8266wifi.cpp
+++ b/ESP8266wifi.cpp
@@ -645,7 +645,7 @@ byte ESP8266wifi::readBuffer(char* buf, byte count, char delim, int timeout) {
     unsigned long stop = millis() + timeout;
 
     while (pos < count) {
-        while(_serialIn->available()) {
+        if(_serialIn->available()) {
             if (_serialIn->peek() == delim)
                 break;
             buf[pos++] = readChar();

--- a/ESP8266wifi.cpp
+++ b/ESP8266wifi.cpp
@@ -639,45 +639,6 @@ byte ESP8266wifi::readCommand(int timeout, const char* text1, const char* text2)
     return 0;
 }
 
-// Unload buffer without delay
-/*byte ESP8266wifi::readCommand(const char* text1, const char* text2) {
-    // setup buffers on stack & copy data from PROGMEM pointers
-    char buf1[16] = {'\0'};
-    char buf2[16] = {'\0'};
-    if (text1 != NULL)
-        strcpy_P(buf1, (char *) text1);
-    if (text2 != NULL)
-        strcpy_P(buf2, (char *) text2);
-    byte len1 = strlen(buf1);
-    byte len2 = strlen(buf2);
-    byte pos1 = 0;
-    byte pos2 = 0;
-
-    // read chars until first match or timeout
-    while (_serialIn->available()) {
-        char c = readChar();
-        pos1 = (c == buf1[pos1]) ? pos1 + 1 : 0;
-        pos2 = (c == buf2[pos2]) ? pos2 + 1 : 0;
-        if (len1 > 0 && pos1 == len1)
-            return 1;
-        if (len2 > 0 && pos2 == len2)
-            return 2;
-    }
-    return 0;
-}*/
-
-// Reads count chars to a buffer, or until delim char is found
-//byte ESP8266wifi::readBuffer(char* buf, byte count, char delim) {
-    //byte pos = 0;
-    //while (_serialIn->available() && pos < count) {
-        //if (_serialIn->peek() == delim)
-            //break;
-        //buf[pos++] = readChar();
-    //}
-    //buf[pos] = '\0';
-    //return pos;
-//}
-
 // Read count chars to a buffer, or until delim char is found, or the request timed out.
 byte ESP8266wifi::readBuffer(char* buf, byte count, char delim, int timeout) {
 	byte pos = 0;
@@ -701,8 +662,6 @@ char ESP8266wifi::readChar() {
     char c = _serialIn->read();
     if (flags.debug)
         _dbgSerial->print(c);
-    //else
-        //delayMicroseconds(50); // don't know why
     return c;
 }
 

--- a/ESP8266wifi.cpp
+++ b/ESP8266wifi.cpp
@@ -667,28 +667,30 @@ byte ESP8266wifi::readCommand(int timeout, const char* text1, const char* text2)
 }*/
 
 // Reads count chars to a buffer, or until delim char is found
-byte ESP8266wifi::readBuffer(char* buf, byte count, char delim) {
-    byte pos = 0;
-    while (_serialIn->available() && pos < count) {
-        if (_serialIn->peek() == delim)
-            break;
-        buf[pos++] = readChar();
-    }
-    buf[pos] = '\0';
-    return pos;
-}
+//byte ESP8266wifi::readBuffer(char* buf, byte count, char delim) {
+    //byte pos = 0;
+    //while (_serialIn->available() && pos < count) {
+        //if (_serialIn->peek() == delim)
+            //break;
+        //buf[pos++] = readChar();
+    //}
+    //buf[pos] = '\0';
+    //return pos;
+//}
 
-// Blocking read count chars to a buffer, or until delim char is found, or the request timed out.
-byte ESP8266wifi::readBuffer2(char* buf, byte count, char delim, int timeout) {
+// Read count chars to a buffer, or until delim char is found, or the request timed out.
+byte ESP8266wifi::readBuffer(char* buf, byte count, char delim, int timeout) {
 	byte pos = 0;
     unsigned long stop = millis() + timeout;
 
-	while (pos < count && millis() < stop) {
+	while (pos < count) {
 		if(_serialIn->available()) {
 			if (_serialIn->peek() == delim)
 				break;
 			buf[pos++] = readChar();
 		}
+		if(millis() > stop)
+			break; //timed out.
 	}
 	buf[pos] = '\0';
 	return pos;

--- a/ESP8266wifi.cpp
+++ b/ESP8266wifi.cpp
@@ -689,7 +689,7 @@ byte ESP8266wifi::readBuffer(char* buf, byte count, char delim, int timeout) {
 				break;
 			buf[pos++] = readChar();
 		}
-		if(millis() > stop)
+		if(timeout > 0 && millis() > stop)
 			break; //timed out.
 	}
 	buf[pos] = '\0';

--- a/ESP8266wifi.cpp
+++ b/ESP8266wifi.cpp
@@ -725,10 +725,10 @@ uint8_t ESP8266wifi::listAps(struct listApDataItem* data, uint8_t len, char* spe
 		writeCommand(CWLAP1, EOL);
 	}
 
-    code = readCommand(4000, CWLAP1, ERROR);
-    if (code == 2){
-	    restart();
-		return 0; //something went wrong.
+	code = readCommand(4000, CWLAP1, ERROR);
+	if (code == 2){
+		restart();
+		goto error; //something went wrong.
     } else if (code == 1) {
 		do {
 			entryOrOk = readCommand(4000, CWLAP2, OK);

--- a/ESP8266wifi.cpp
+++ b/ESP8266wifi.cpp
@@ -706,7 +706,7 @@ char ESP8266wifi::readChar() {
     return c;
 }
 
-uint8_t ESP8266wifi::listAps(struct listApDataItem* data, uint8_t len, char* specificSSID) {
+uint8_t ESP8266wifi::listAps(struct listApDataItem* data, uint8_t len, char* specificSSID, char* specificMAC, int specificChannel) {
 	byte entryOrOk = 0;
 	byte code = 0;
 	char* token;
@@ -717,10 +717,21 @@ uint8_t ESP8266wifi::listAps(struct listApDataItem* data, uint8_t len, char* spe
 
 	if(specificSSID != NULL) {
 		//issue request for specific ap; may not work on older firmware
-		//TODO: extend to also being able setti
 		writeCommand(CWLAP3);
 		_serialOut->print(specificSSID);
-		writeCommand(DOUBLE_QUOTE, EOL);
+		writeCommand(DOUBLE_QUOTE);
+		
+		if(specificMAC != NULL) {
+			writeCommand(COMMA, DOUBLE_QUOTE);
+			_serialOut->print(specificMAC);
+			writeCommand(DOUBLE_QUOTE);
+
+			if(specificChannel > 0) {
+				writeCommand(COMMA);
+				_serialOut->print(specificChannel);
+			}
+		}
+		_serialOut->println();
 	} else {
 		writeCommand(CWLAP1, EOL);
 	}
@@ -786,6 +797,6 @@ error:
 	return 0;
 }
 
-uint8_t ESP8266wifi::listAp(struct listApDataItem* data, char* ssid) {
-	return listAps(data, 1, ssid);
+uint8_t ESP8266wifi::listAp(struct listApDataItem* data, char* ssid, char* mac, int channel) {
+	return listAps(data, 1, ssid, mac, channel);
 }

--- a/ESP8266wifi.cpp
+++ b/ESP8266wifi.cpp
@@ -690,15 +690,16 @@ uint8_t ESP8266wifi::listAps(struct listApDataItem* data, uint8_t len, char* spe
                 _serialOut->print(specificChannel);
             }
         }
-        _serialOut->println();
+		writeCommand(EOL);
     } else {
+		//request all aps in range
         writeCommand(CWLAP1, EOL);
     }
 
     code = readCommand(4000, CWLAP1, ERROR);
     if (code == 2){
         restart();
-        goto error; //something went wrong.
+        goto error; //something went wrong, e.g. filtering is not supported
     } else if (code == 1) {
         do {
             entryOrOk = readCommand(4000, CWLAP2, OK);

--- a/ESP8266wifi.h
+++ b/ESP8266wifi.h
@@ -189,7 +189,7 @@ private:
     char msgIn[MSG_BUFFER_MAX]; //buffer for listen method = limit of incoming message..
 
     void writeCommand(const char* text1, const char* text2 = NULL);
-    byte readCommand(int timeout, const char* text1, const char* text2 = NULL);
+    byte readCommand(int timeout, const char* text1 = NULL, const char* text2 = NULL);
     byte readBuffer(char* buf, byte count, char delim = '\0', int timeout = 0);
     char readChar();
 

--- a/ESP8266wifi.h
+++ b/ESP8266wifi.h
@@ -191,8 +191,8 @@ private:
     void writeCommand(const char* text1, const char* text2 = NULL);
     byte readCommand(int timeout, const char* text1 = NULL, const char* text2 = NULL);
     //byte readCommand(const char* text1, const char* text2);
-    byte readBuffer(char* buf, byte count, char delim = '\0');
-    byte readBuffer2(char* buf, byte count, char delim = '\0', int timeout = 500);
+    //byte readBuffer(char* buf, byte count, char delim = '\0');
+    byte readBuffer(char* buf, byte count, char delim = '\0', int timeout = 0);
     char readChar();
 
     Stream* _dbgSerial;

--- a/ESP8266wifi.h
+++ b/ESP8266wifi.h
@@ -57,10 +57,27 @@ struct Flags   // 1 byte value (on a system where 8 bits is a byte
          connectToServerUsingTCP:1;
 };
 
+enum listApTypes {WIFI_OPEN = 0,
+	WIFI_WEP = 1,
+	WIFI_WPA_PSK = 2,
+	WIFI_WPA2_PSK = 3,
+	WIFI_WPA_WPA2_PSK = 4,
+};
+struct listApDataItem {
+	listApTypes type;
+	char ssid[32];
+	int8_t rssi;
+	char mac[18];
+	uint8_t channel;
+};
+
 class ESP8266wifi
 {
     
 public:
+	uint8_t listAps(struct listApDataItem* data, uint8_t len, char* specificSSID = NULL);
+	uint8_t listAp(struct listApDataItem* data, char* ssid);
+
     /*
      * Will pull resetPin low then high to reset esp8266, connect this pin to CHPD pin
      */
@@ -169,6 +186,7 @@ private:
     byte readCommand(int timeout, const char* text1 = NULL, const char* text2 = NULL);
     //byte readCommand(const char* text1, const char* text2);
     byte readBuffer(char* buf, byte count, char delim = '\0');
+    byte readBuffer2(char* buf, byte count, char delim = '\0', int timeout = 500);
     char readChar();
 
     Stream* _dbgSerial;

--- a/ESP8266wifi.h
+++ b/ESP8266wifi.h
@@ -75,9 +75,6 @@ class ESP8266wifi
 {
     
 public:
-	uint8_t listAps(struct listApDataItem* data, uint8_t len, char* specificSSID = NULL);
-	uint8_t listAp(struct listApDataItem* data, char* ssid);
-
     /*
      * Will pull resetPin low then high to reset esp8266, connect this pin to CHPD pin
      */
@@ -95,7 +92,16 @@ public:
     bool begin(); // reset and set echo and other stuff
     
     bool isStarted();
-    
+
+	/*
+	 * Will fill datastructure with access point information.
+	 */
+	uint8_t listAps(struct listApDataItem* data, uint8_t len, char* specificSSID = NULL, char* specificMAC = NULL, int specificChannel = -1);
+	/*
+	 * Will scan for a specific access point.
+	 */
+	uint8_t listAp(struct listApDataItem* data, char* ssid, char* mac = NULL, int channel = -1);
+
     /*
      * Connect to AP using wpa encryption
      * (reconnect logic is applied, if conn lost or not established, or esp8266 restarted)

--- a/ESP8266wifi.h
+++ b/ESP8266wifi.h
@@ -189,9 +189,7 @@ private:
     char msgIn[MSG_BUFFER_MAX]; //buffer for listen method = limit of incoming message..
 
     void writeCommand(const char* text1, const char* text2 = NULL);
-    byte readCommand(int timeout, const char* text1 = NULL, const char* text2 = NULL);
-    //byte readCommand(const char* text1, const char* text2);
-    //byte readBuffer(char* buf, byte count, char delim = '\0');
+    byte readCommand(int timeout, const char* text1, const char* text2 = NULL);
     byte readBuffer(char* buf, byte count, char delim = '\0', int timeout = 0);
     char readChar();
 

--- a/ESP8266wifi.h
+++ b/ESP8266wifi.h
@@ -58,17 +58,17 @@ struct Flags   // 1 byte value (on a system where 8 bits is a byte
 };
 
 enum listApTypes {WIFI_OPEN = 0,
-	WIFI_WEP = 1,
-	WIFI_WPA_PSK = 2,
-	WIFI_WPA2_PSK = 3,
-	WIFI_WPA_WPA2_PSK = 4,
+    WIFI_WEP = 1,
+    WIFI_WPA_PSK = 2,
+    WIFI_WPA2_PSK = 3,
+    WIFI_WPA_WPA2_PSK = 4,
 };
 struct listApDataItem {
-	listApTypes type;
-	char ssid[32];
-	int8_t rssi;
-	char mac[18];
-	uint8_t channel;
+    listApTypes type;
+    char ssid[32];
+    int8_t rssi;
+    char mac[18];
+    uint8_t channel;
 };
 
 class ESP8266wifi
@@ -93,14 +93,14 @@ public:
     
     bool isStarted();
 
-	/*
-	 * Will fill datastructure with access point information.
-	 */
-	uint8_t listAps(struct listApDataItem* data, uint8_t len, char* specificSSID = NULL, char* specificMAC = NULL, int specificChannel = -1);
-	/*
-	 * Will scan for a specific access point.
-	 */
-	uint8_t listAp(struct listApDataItem* data, char* ssid, char* mac = NULL, int channel = -1);
+    /*
+     * Will fill datastructure with access point information.
+     */
+    uint8_t listAps(struct listApDataItem* data, uint8_t len, char* specificSSID = NULL, char* specificMAC = NULL, int specificChannel = -1);
+    /*
+     * Will scan for a specific access point.
+     */
+    uint8_t listAp(struct listApDataItem* data, char* ssid, char* mac = NULL, int channel = -1);
 
     /*
      * Connect to AP using wpa encryption

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Note: It is really only the send method that can detect a lost connection to the
 In ESP8266wifi.h you can change some stuff:
 * **HW_RESET_RETRIES 3** - is the maximum number of times begin() will try to start the ESP8266 module
 * **SERVER_CONNECT_RETRIES_BEFORE_HW_RESET 30** - is the nr of time the watchdog will try to establish connection to a server before a hardware reset of the ESP8266 is performed
-* The maximum number of characters for incoming and outgoing messages can be changes by editing:
+* The maximum number of characters for incoming and outgoing messages can be changes by editing (note: listAp requires about 80 chars for msgIn):
     * char msgOut[26];
     * char msgIn[26];
 * If the limit for ssid and password length does not suite you, please change:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,22 @@ ESP8266#Module_Pin_Description
 * **return** will return a true or false depending if the module was properly initiated
 * **Example:** `boolean esp8266started = wifi.begin();`
 
+## Get access point information
+**uint8_t listAps(struct listApDataItem* data, uint8_t len, char* specificSSID = NULL, char* specificMAC = NULL, int specificChannel = -1) lists information about access points
+* **data* this array is used to store information read from the ESP8266
+* **len this defines the size of the given array
+* **specificSSID optionally filter for a specific SSID
+* **specificMAC optionally filter for a specific MAC address
+* **specificChannel optionally filter for a specific channel
+* **Example:** `struct listApDataItem data[10]; uint8_t foundAps = wifi.listAps(data, 10);`
+
+**uint8_t listAp(struct listApDataItem* data, char* ssid, char* mac = NULL, int channel = -1) gets information about a specific access point
+* **data this object is used to store data information from the ESP8266
+* **ssid filter for a specific SSID
+* **specificMAC optionally filter for a specific MAC address
+* **specificChannel optionally filter for a specific channel
+* **Example:** `struct listApDataItem data; uint8_t foundAps = wifi.listAp(&data, "myaccesspoint");`
+
 ## Connecting to an access point
 **boolean connectToAP(char * ssid, char*  password)** tells the ESP8266 to connect to an accesspoint
 * **ssid** the ssid (station name) to be used. Note that this method uses char arrays as input. See http://arduino.cc/en/Reference/StringToCharArray for how to convert an arduino string object to a char array (max 15 chars)

--- a/README.md
+++ b/README.md
@@ -41,18 +41,18 @@ ESP8266#Module_Pin_Description
 
 ## Get access point information
 **uint8_t listAps(struct listApDataItem* data, uint8_t len, char* specificSSID = NULL, char* specificMAC = NULL, int specificChannel = -1) lists information about access points
-* **data* this array is used to store information read from the ESP8266
-* **len this defines the size of the given array
-* **specificSSID optionally filter for a specific SSID
-* **specificMAC optionally filter for a specific MAC address
-* **specificChannel optionally filter for a specific channel
+* **data** this array is used to store information read from the ESP8266
+* **len** this defines the size of the given array
+* **specificSSID** optionally filter for a specific SSID
+* **specificMAC** optionally filter for a specific MAC address
+* **specificChannel** optionally filter for a specific channel
 * **Example:** `struct listApDataItem data[10]; uint8_t foundAps = wifi.listAps(data, 10);`
 
 **uint8_t listAp(struct listApDataItem* data, char* ssid, char* mac = NULL, int channel = -1) gets information about a specific access point
-* **data this object is used to store data information from the ESP8266
-* **ssid filter for a specific SSID
-* **specificMAC optionally filter for a specific MAC address
-* **specificChannel optionally filter for a specific channel
+* **data** this object is used to store data information from the ESP8266
+* **ssid** filter for a specific SSID
+* **specificMAC** optionally filter for a specific MAC address
+* **specificChannel** optionally filter for a specific channel
 * **Example:** `struct listApDataItem data; uint8_t foundAps = wifi.listAp(&data, "myaccesspoint");`
 
 ## Connecting to an access point

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ESP8266#Module_Pin_Description
 * **Example:** `boolean esp8266started = wifi.begin();`
 
 ## Get access point information
-**uint8_t listAps(struct listApDataItem** data, uint8_t len, char* specificSSID = NULL, char* specificMAC = NULL, int specificChannel = -1) lists information about access points
+**uint8_t listAps(struct listApDataItem* data, uint8_t len, char* specificSSID = NULL, char* specificMAC = NULL, int specificChannel = -1)** lists information about access points
 * **data** this array is used to store information read from the ESP8266
 * **len** this defines the size of the given array
 * **specificSSID** optionally filter for a specific SSID
@@ -48,7 +48,7 @@ ESP8266#Module_Pin_Description
 * **specificChannel** optionally filter for a specific channel
 * **Example:** `struct listApDataItem data[10]; uint8_t foundAps = wifi.listAps(data, 10);`
 
-**uint8_t listAp(struct listApDataItem** data, char* ssid, char* mac = NULL, int channel = -1) gets information about a specific access point
+**uint8_t listAp(struct listApDataItem* data, char* ssid, char* mac = NULL, int channel = -1)** gets information about a specific access point
 * **data** this object is used to store data information from the ESP8266
 * **ssid** filter for a specific SSID
 * **specificMAC** optionally filter for a specific MAC address

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ESP8266#Module_Pin_Description
 * **Example:** `boolean esp8266started = wifi.begin();`
 
 ## Get access point information
-**uint8_t listAps(struct listApDataItem* data, uint8_t len, char* specificSSID = NULL, char* specificMAC = NULL, int specificChannel = -1) lists information about access points
+**uint8_t listAps(struct listApDataItem** data, uint8_t len, char* specificSSID = NULL, char* specificMAC = NULL, int specificChannel = -1) lists information about access points
 * **data** this array is used to store information read from the ESP8266
 * **len** this defines the size of the given array
 * **specificSSID** optionally filter for a specific SSID
@@ -48,7 +48,7 @@ ESP8266#Module_Pin_Description
 * **specificChannel** optionally filter for a specific channel
 * **Example:** `struct listApDataItem data[10]; uint8_t foundAps = wifi.listAps(data, 10);`
 
-**uint8_t listAp(struct listApDataItem* data, char* ssid, char* mac = NULL, int channel = -1) gets information about a specific access point
+**uint8_t listAp(struct listApDataItem** data, char* ssid, char* mac = NULL, int channel = -1) gets information about a specific access point
 * **data** this object is used to store data information from the ESP8266
 * **ssid** filter for a specific SSID
 * **specificMAC** optionally filter for a specific MAC address

--- a/README.md
+++ b/README.md
@@ -47,7 +47,18 @@ ESP8266#Module_Pin_Description
 * **specificMAC** optionally filter for a specific MAC address
 * **specificChannel** optionally filter for a specific channel
 * **return** will return the number of found access points
-* **Example:** `struct listApDataItem data[10]; uint8_t foundAps = wifi.listAps(data, 10);`
+* **Example:**
+```
+struct listApDataItem data[10]; //buffer information
+uint8_t foundAps = wifi.listAps(data, 10); //request
+for(uint8_t i = 0; i < min(foundAps, 10); i++) {
+  Serial.println(foundAps[i].ssid);
+  Serial.println(foundAps[i].mac);
+  Serial.println(foundAps[i].channel);
+  Serial.println(foundAps[i].rssi);
+  Serial.println((!foundAps[i].type) ? "open" : "secured");
+}
+```
 
 **uint8_t listAp(struct listApDataItem* data, char* ssid, char* mac = NULL, int channel = -1)** gets information about a specific access point
 * **data** this object is used to store data information from the ESP8266

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ ESP8266#Module_Pin_Description
 * **specificSSID optionally filter for a specific SSID
 * **specificMAC optionally filter for a specific MAC address
 * **specificChannel optionally filter for a specific channel
+* **return** will return the number of found access points
 * **Example:** `struct listApDataItem data[10]; uint8_t foundAps = wifi.listAps(data, 10);`
 
 **uint8_t listAp(struct listApDataItem* data, char* ssid, char* mac = NULL, int channel = -1) gets information about a specific access point
@@ -53,6 +54,7 @@ ESP8266#Module_Pin_Description
 * **ssid filter for a specific SSID
 * **specificMAC optionally filter for a specific MAC address
 * **specificChannel optionally filter for a specific channel
+* **return** will return the number of found access points
 * **Example:** `struct listApDataItem data; uint8_t foundAps = wifi.listAp(&data, "myaccesspoint");`
 
 ## Connecting to an access point


### PR DESCRIPTION
New methods listAps and listAp allow scanning for all APs in range or a specific SSID (& MAC & channel), respectively.

A new Enum has been introduced represendting AP security types (Open, WEP, WPA, ...).
For AP information, there is a new struct listApDataItem.
Further, the readBuffer method has been changed such that it now supports a timeout instead of depending on data being available (reading data otherwise causes trouble with reasonably small serial RX buffers).

The filtering features may require a newer chip firmware version.
[Tested with:
AT version:0.40.0.0(Aug  8 2015 14:45:58)
SDK version:1.3.0
Ai-Thinker Technology Co.,Ltd.
Build:1.3.0.2 Sep 11 2015 11:48:04]
