### PR TITLE
Increase max. password length to 31

### DIFF
--- a/ESP8266wifi.h
+++ b/ESP8266wifi.h
@@ -147,12 +147,12 @@ private:
     
     bool connectToAP();
     char _ssid[16];
-    char _password[16];
+    char _password[32];
     
     bool startLocalAp();
     bool startLocalServer();
     char _localAPSSID[16];
-    char _localAPPassword[16];
+    char _localAPPassword[32];
     char _localAPChannel[3];
     char _localServerPort[6];
     WifiConnection _connections[MAX_CONNECTIONS];


### PR DESCRIPTION
I propose increasing the maximal password length for clients and APs from 15 to 31.
I think this is neccessary because when your password contains special characters they have to be escaped with a backslash, which means those characters are counted twice which decreases security of the usable passwords.
