### PR TITLE
Corrected pgmspace include on ESP8266

### DIFF
--- a/ESP8266wifi.h
+++ b/ESP8266wifi.h
@@ -21,12 +21,11 @@
 
 #include <inttypes.h>
 
-#if defined ( ESP8266 )
-  #include <pgmspace.h>
+#if defined(ESP8266)
+#include <pgmspace.h>
 #else
-  #include <avr/pgmspace.h>
+#include <avr/pgmspace.h>
 #endif
-
 
 #include "HardwareSerial.h"
 

--- a/ESP8266wifi.h
+++ b/ESP8266wifi.h
@@ -20,7 +20,14 @@
 #endif
 
 #include <inttypes.h>
-#include <avr/pgmspace.h>
+
+#if defined ( ESP8266 )
+  #include <pgmspace.h>
+#else
+  #include <avr/pgmspace.h>
+#endif
+
+
 #include "HardwareSerial.h"
 
 #define SERVER '4'


### PR DESCRIPTION
Added correct pgmspace include for ESP8266. Closes #39 