### PR TITLE
Password too short

### DIFF
--- a/ESP8266wifi.h
+++ b/ESP8266wifi.h
@@ -153,7 +153,7 @@ private:
     
     bool connectToAP();
     char _ssid[16];
-    char _password[16];
+    char _password[30];
     
     bool startLocalAp();
     bool startLocalServer();


### PR DESCRIPTION
Some WIFI routers use passwords longer than 16 characters.