### PR TITLE
readBuffer already strips commas

### DIFF
--- a/SerialESP8266wifi.cpp
+++ b/SerialESP8266wifi.cpp
@@ -549,7 +549,9 @@ WifiMessage SerialESP8266wifi::listenForIncomingMessage(int timeout){
             flags.connectedToServer = true;
         readChar(); // removing comma
         readBuffer(&buf[0], sizeof(buf) - 1, ':'); // read char count
-        readChar(); // removing ':' delim
+	// kiwichrish, commented out following line.  Comma is already read from buffer inline above.
+	// causes trucation of message.
+	// readChar(); // removing ':' delim
         byte length = atoi(buf);
         readBuffer(&msgIn[0], min(length, sizeof(msgIn) - 1));
         msg.hasData = true;
@@ -586,7 +588,9 @@ WifiMessage SerialESP8266wifi::getIncomingMessage(void) {
             flags.connectedToServer = true;
         readChar(); // removing comma
         readBuffer(&buf[0], sizeof(buf) - 1, ':'); // read char count
-        readChar(); // removing ':' delim
+	// kiwichrish, commented out following line.  Comma is already read from buffer inline above.
+	// causes trucation of message.
+        // readChar(); // removing ':' delim
         byte length = atoi(buf);
         readBuffer(&msgIn[0], min(length, sizeof(msgIn) - 1));
         msg.hasData = true;


### PR DESCRIPTION
Hi-ho,

Per the change below.  Using library for a simple restful API solution and found that the extra readChar(); was not required as the readBuffer already removes the colon.

This results in truncating replies to the GET by one character, and appending one from the next line to the message returned.